### PR TITLE
remove outline:thin dotted

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -79,12 +79,6 @@
 	main {
 		display: block;
 	}
-
-	// Standardise outline styles
-	:focus {
-		outline: thin dotted;
-		outline-offset: 1px;
-	}
 }
 
 /// Adds normalising styles to link elements


### PR DESCRIPTION
The new focus styles that are getting overridden by these old ones in sites that use o-normalise. 
Can we consider removing these lines please?