### PR TITLE
Amend focus style for links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,5 +11,8 @@
   "main": [
     "main.scss",
 	"main.js"
-  ]
+  ],
+  "dependencies": {
+    "o-colors": "^4.0.4"
+  }
 }

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,3 +1,5 @@
 <div>
 	<h1>Basic Demo</h1>
+	<a href="ft.com"> A link is here </a>
+	<h2><a href="ft.com">Read more</a></h2>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,5 @@
+@import 'o-colors/main';
+
 @import 'src/scss/variables';
 @import 'src/scss/mixins';
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,9 +82,11 @@
 
 	// Standardise outline styles
 	:focus {
-		outline: thin dotted;
-		outline-offset: 1px;
+		background-color: oColorsGetPaletteColor('teal-100');
+		outline: 2px solid oColorsGetPaletteColor('teal-100');
+		color:  oColorsGetPaletteColor('black-80');
 	}
+
 }
 
 /// Adds normalising styles to link elements


### PR DESCRIPTION
This changes the focus style for links when you tab through a page. 

**FROM (default)** 
<img width="267" alt="screen shot 2017-09-26 at 12 09 19" src="https://user-images.githubusercontent.com/10324129/30857490-cb5903c0-a2b3-11e7-9ac9-600de5b15333.png">

**TO**
<img width="116" alt="screen shot 2017-09-26 at 12 13 39" src="https://user-images.githubusercontent.com/10324129/30857583-2df18b7e-a2b4-11e7-9e70-d050d2d1eee0.png">


The full description of the problem is here and a gif of the final desired version: https://github.com/Financial-Times/o-normalise/pull/8

**I have also:**
• added o-colors to get colours working
• amended the html demo to add a couple of link tags so you can see the effect of the change better 
I have not changed the focus style of buttons, this is pending some changes due to obuttons. 