### PR TITLE
Update focus without introducing a breaking change

### DIFF
--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -1,3 +1,5 @@
 <div>
 	<h1>Basic Demo</h1>
+	<a href="ft.com"> A link is here </a>
+	<h2><a href="ft.com">Read more</a></h2>
 </div>

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -88,9 +88,9 @@
 			outline: 2px solid oColorsGetPaletteColor('teal-100');
 			color:  oColorsGetPaletteColor('black-80');
 		*/
-		background-color: #1AECFF;
-		outline: 2px solid #1AECFF;
-		color: #33302E;
+		background-color: #1aecff; //oColorsGetPaletteColor('teal-100');
+		outline: 2px solid #1aecff; //oColorsGetPaletteColor('teal-100');
+		color: #33302e; //oColorsGetPaletteColor('black-80');
 	}
 }
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,8 +82,15 @@
 
 	// Standardise outline styles
 	:focus {
-		outline: thin dotted;
-		outline-offset: 1px;
+		/* TODO: In next major release, add a dependency on o-colors here. Should be
+		something like this:
+			background-color: oColorsGetPaletteColor('teal-100');
+			outline: 2px solid oColorsGetPaletteColor('teal-100');
+			color:  oColorsGetPaletteColor('black-80');
+		*/
+		background-color: #1AECFF;
+		outline: 2px solid #1AECFF;
+		color: #33302E;
 	}
 }
 


### PR DESCRIPTION
This should be added with an o-colors dependency, however this
constitutes a breaking change as it could introduce a bower conflict
in a build service request which build service users would have to
re-depoly to fix.

So we can get this change out to as many people as quickly as possible,
this change adds the color changes without introducing a new
dependency.

This should be removed when we make the next breaking update.