### PR TITLE
Stop installing phantomjs, ensure we only use obt version 7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,8 @@
 machine:
-  pre:
-    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
   node:
     version: 6
   post:
-    - npm install -g origami-build-tools
+    - npm install -g origami-build-tools@^7
 dependencies:
   override:
     - obt install
@@ -12,5 +10,5 @@ dependencies:
     - "node_modules"
 test:
   override:
-    - obt test
     - obt verify
+    - obt test


### PR DESCRIPTION
- Removed the phantomjs installation step as obt no longer uses phantomjs.
- Reordered the test tasks as the verification task is faster to run, meaning if the build had code not conforming to the origami coding conventions, the build will fail faster than before.
- Changed the installation of obt to ensure we only install obt 7, this is to safeguard against a new major version of obt being released and breaking builds of this project.
