### PR TITLE
Remove link focus styles and colors dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,5 @@
     "main.js"
   ],
   "dependencies": {
-    "o-colors": "^4.0.0"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,7 +1,4 @@
-@import 'o-colors/main';
-
 @import 'src/scss/variables';
-@import 'src/scss/colors';
 @import 'src/scss/mixins';
 
 @if ($o-normalise-is-silent == false) {

--- a/src/scss/_colors.scss
+++ b/src/scss/_colors.scss
@@ -1,3 +1,0 @@
-@include oColorsSetUseCase(o-normalise-focus, 'border', 'teal-100');
-@include oColorsSetUseCase(o-normalise-focus, 'background', 'teal-100');
-@include oColorsSetUseCase(o-normalise-focus, 'text', 'slate');

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,28 +82,14 @@
 
 	// Standardise outline styles
 	:focus {
-		outline: 2px solid oColorsGetColorFor('o-normalise-focus', 'border');
+		outline: 2px solid $o-normalise-focus-color;
 	}
 
 	input:focus,
 	textarea:focus,
 	select:focus {
-		box-shadow: 0 0 0 1px oColorsGetColorFor('o-normalise-focus', 'border');
+		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
-
-	a:focus {
-		@include oNormaliseLinkFocus()
-	}
-
-}
-
-// A focus style just for links
-@mixin oNormaliseLinkFocus {
-	outline: none;
-	background-color: oColorsGetColorFor('o-normalise-focus', 'background');
-	// In many cases, css precedence will mean that this is overidden. This mixin
-	// is provided so you can include it yourself at the right precedence
-	color: oColorsGetColorFor('o-normalise-focus', 'text');
 }
 
 /// Adds normalising styles to link elements

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -11,3 +11,6 @@ $o-normalise-grid-gutters: (
 
 /// Standardised border radius
 $o-normalise-border-radius: 0;
+
+/// TODO: Update this to the o-colors value in the next major (it's teal-100)
+$o-normalise-focus-color: #1aecff


### PR DESCRIPTION
So...

Adding blanket focus styles for links that change the background-color
and color properties has some weird side effects on things that have
already defined or part defined their own focus styles. These side
effects are things like:

```css
// In o-normalise
a:focus {
  color: red;
  background-color:black
}

// In some other component or bit of the page
.o-component a:focus {
  color:black
}
```

This results in the focus state for the `o-component a` being black on
black.

So, to avoid this problem, we're just going to set the outline, which
shouldn't introduce any dire user experience problems as browsers
already use this to style focus states as a default.

This commit also removes the o-colors dependency as we can go without it
and so avoid a breaking change.