### PR TITLE
Only have focus styles when navigating via keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Foundation styles and standardised utilities
 
 - [Usage](#usage)
 	- [Sass](#sass)
+	- [Focus States](#focus-states)
 - [Contributing](#contributing)
 - [Contact](#contact)
 - [Licence](#licence)
@@ -36,6 +37,14 @@ The following mixins apply normalising styles to groups of HTML elements, these 
 
 - `$o-normalise-grid-gutters` - provides a map of standardised grid gutter sizes
 - `$o-normalise-border-radius` - provides a standardised border radius value
+
+### Focus States
+
+`o-normalise` provides default focus states using the `:focus-visible` pseudo-class. This applies while an element matches the `:focus` pseudo-class and the UA determines that the focus should be specially indicated.
+
+No browser supports `:focus-visible` right now (31st Jan 2018) but there is [a polyfill](https://github.com/WICG/focus-visible) which roughly mimics the behaviour by adding a class `.focus-visible` to an element if it should have `:focus-visible` applied to it. Integrate [the polyfill](https://github.com/WICG/focus-visible) with your project to apply these focus styles.
+
+`:focus` is used as a fallback in `core` mode.
 
 ## Contributing
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -81,7 +81,8 @@
 	}
 
 	// Standardise focus styles.
-	.core :focus, .focus-visible {
+	.core :focus,
+	.focus-visible {
 		outline: 2px solid $o-normalise-focus-color;
 	}
 	

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -92,16 +92,10 @@
 
 	.core input:focus, input.focus-visible,
 	.core textarea:focus, textarea.focus-visible,
-	.core select:focus, select.focus-visible,
-	.core input:focus, input.focus-visible,
-	.core textarea:focus, textarea.focus-visible,
-	.core select:focus, select.focus-visible,{
+	.core select:focus, select.focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
 	
-	input:focus-visible,
-	textarea:focus-visible,
-	select:focus-visible,
 	input:focus-visible,
 	textarea:focus-visible,
 	select:focus-visible {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -80,27 +80,38 @@
 		display: block;
 	}
 
-	// Standardise focus styles.
-	.core :focus,
-	.focus-visible {
-		outline: 2px solid $o-normalise-focus-color;
+	:not(body.js-focus-visible) {
+		// Standardise focus styles.
+		:focus {
+			outline: 2px solid $o-normalise-focus-color;
+		}
+
+		input:focus,
+		textarea:focus,
+		select:focus {
+			box-shadow: 0 0 0 1px $o-normalise-focus-color;
+		}
 	}
-	
+
+	body.js-focus-visible {
+		// Standardise focus styles.
+		.focus-visible {
+			outline: 2px solid $o-normalise-focus-color;
+		}
+		// sass-lint:disable no-qualifying-elements
+		input.focus-visible,
+		textarea.focus-visible,
+		select.focus-visible {
+			box-shadow: 0 0 0 1px $o-normalise-focus-color;
+		}
+		// sass-lint:enable no-qualifying-elements
+	}
+
 	:focus-visible {
 		outline: 2px solid $o-normalise-focus-color;
 	}
 
-	// sass-lint:disable no-qualifying-elements
-	.core input:focus,
-	input.focus-visible,
-	.core textarea:focus,
-	textarea.focus-visible,
-	.core select:focus,
-	select.focus-visible {
-		box-shadow: 0 0 0 1px $o-normalise-focus-color;
-	}
-	// sass-lint:enable no-qualifying-elements
-	
+
 	input:focus-visible,
 	textarea:focus-visible,
 	select:focus-visible {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -81,17 +81,30 @@
 	}
 
 	// Standardise focus styles.
-	.core :focus, .focus-visible, :focus-visible {
+	.core :focus, .focus-visible {
+		outline: 2px solid $o-normalise-focus-color;
+	}
+	
+	:focus-visible {
 		outline: 2px solid $o-normalise-focus-color;
 	}
 
 
-	.core input:focus, input.focus-visible, input:focus-visible,
-	.core textarea:focus, textarea.focus-visible, textarea:focus-visible,
-	.core select:focus, select.focus-visible, select:focus-visible,
-	.core input:focus, input.focus-visible, input:focus-visible,
-	.core textarea:focus, textarea.focus-visible, textarea:focus-visible,
-	.core select:focus, select.focus-visible, select:focus-visible {
+	.core input:focus, input.focus-visible,
+	.core textarea:focus, textarea.focus-visible,
+	.core select:focus, select.focus-visible,
+	.core input:focus, input.focus-visible,
+	.core textarea:focus, textarea.focus-visible,
+	.core select:focus, select.focus-visible,{
+		box-shadow: 0 0 0 1px $o-normalise-focus-color;
+	}
+	
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -81,14 +81,14 @@
 	}
 
 	// Standardise focus styles.
-	:focus {
+	.focus-visible, :focus-visible { {
 		outline: 2px solid $o-normalise-focus-color;
 	}
 
 
-	input:focus,
-	textarea:focus,
-	select:focus {
+	input.focus-visible, input:focus-visible {,
+	textarea.focus-visible, textarea:focus-visible,
+	select.focus-visible, select:focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -90,9 +90,12 @@
 	}
 
 
-	.core input:focus, input.focus-visible,
-	.core textarea:focus, textarea.focus-visible,
-	.core select:focus, select.focus-visible {
+	.core input:focus,
+	input.focus-visible,
+	.core textarea:focus,
+	textarea.focus-visible,
+	.core select:focus,
+	select.focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
 	

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -80,6 +80,8 @@
 		display: block;
 	}
 
+	// Apply :focus styles as a fallback
+	// These styles will be applied to all browsers that don't use the polyfill, this includes browsers which support the feature natively.
 	:not(body.js-focus-visible) {
 		// Standardise focus styles.
 		:focus {
@@ -93,6 +95,7 @@
 		}
 	}
 
+	// `.js-focus-visible` is added to the body dom node when the focus-visible polyfill is applied
 	body.js-focus-visible {
 		// Standardise focus styles.
 		.focus-visible {
@@ -107,10 +110,21 @@
 		// sass-lint:enable no-qualifying-elements
 	}
 
+	// These styles will be ignored by browsers which do not recognise the :focus-visible selector (as per the third bullet point in https://www.w3.org/TR/selectors-3/#Conformance)
+	// If a browser supports :focus-visible we unset the :focus styles that were applied above (within the :not(body.js-focus-visible) block).
+	:focus-visible, :focus {
+		outline: unset;
+	}
+	:focus-visible,
+	input:focus,
+	textarea:focus,
+	select:focus {
+		box-shadow: unset;
+	}
+
 	:focus-visible {
 		outline: 2px solid $o-normalise-focus-color;
 	}
-
 
 	input:focus-visible,
 	textarea:focus-visible,

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -81,14 +81,17 @@
 	}
 
 	// Standardise focus styles.
-	.focus-visible, :focus-visible { {
+	.core :focus, .focus-visible, :focus-visible {
 		outline: 2px solid $o-normalise-focus-color;
 	}
 
 
-	input.focus-visible, input:focus-visible {,
-	textarea.focus-visible, textarea:focus-visible,
-	select.focus-visible, select:focus-visible {
+	.core input:focus, input.focus-visible, input:focus-visible,
+	.core textarea:focus, textarea.focus-visible, textarea:focus-visible,
+	.core select:focus, select.focus-visible, select:focus-visible,
+	.core input:focus, input.focus-visible, input:focus-visible,
+	.core textarea:focus, textarea.focus-visible, textarea:focus-visible,
+	.core select:focus, select.focus-visible, select:focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -90,7 +90,7 @@
 		outline: 2px solid $o-normalise-focus-color;
 	}
 
-
+	// sass-lint:disable no-qualifying-elements
 	.core input:focus,
 	input.focus-visible,
 	.core textarea:focus,
@@ -99,6 +99,7 @@
 	select.focus-visible {
 		box-shadow: 0 0 0 1px $o-normalise-focus-color;
 	}
+	// sass-lint:enable no-qualifying-elements
 	
 	input:focus-visible,
 	textarea:focus-visible,

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,7 +82,7 @@
 
 	// Apply :focus styles as a fallback
 	// These styles will be applied to all browsers that don't use the polyfill, this includes browsers which support the feature natively.
-	:not(body.js-focus-visible) {
+	:not(body.js-focus-visible) { // sass-lint:disable-line no-qualifying-elements
 		// Standardise focus styles.
 		:focus {
 			outline: 2px solid $o-normalise-focus-color;
@@ -96,23 +96,24 @@
 	}
 
 	// `.js-focus-visible` is added to the body dom node when the focus-visible polyfill is applied
+	// sass-lint:disable no-qualifying-elements
 	body.js-focus-visible {
 		// Standardise focus styles.
 		.focus-visible {
 			outline: 2px solid $o-normalise-focus-color;
 		}
-		// sass-lint:disable no-qualifying-elements
 		input.focus-visible,
 		textarea.focus-visible,
 		select.focus-visible {
 			box-shadow: 0 0 0 1px $o-normalise-focus-color;
 		}
-		// sass-lint:enable no-qualifying-elements
 	}
+	// sass-lint:enable no-qualifying-elements
 
 	// These styles will be ignored by browsers which do not recognise the :focus-visible selector (as per the third bullet point in https://www.w3.org/TR/selectors-3/#Conformance)
 	// If a browser supports :focus-visible we unset the :focus styles that were applied above (within the :not(body.js-focus-visible) block).
-	:focus-visible, :focus {
+	:focus-visible,
+	:focus {
 		outline: unset;
 	}
 	:focus-visible,


### PR DESCRIPTION
Currently if an element has a `:focus` style it will be applied when the element is either tabbed to via a keyboard or clicked on via a mouse. We have had many complaints from users about the focus styles showing when clicking an element, they would prefer the focus styles to only apply when tabbing via a keyboard. The CSS proposal `:focus-visible` is aimed at solving this. The `:focus-visible` pseudo-class applies while an element matches the :focus pseudo-class, and the UA determines via heuristics that the focus should be specially indicated on the element.

No browser supports `:focus-visible` right now (31st Jan 2018) but there is a polyfill which roughly mimics the behaviour by adding a class named `focus-visible` to an element if it should have `:focus-visible` applied to it.

The polyfill uses two heuristics to determine whether the keyboard is being used:

- a focus event immediately following a keydown event where the key pressed was either Tab, Shift + Tab, or an arrow key.
- focus moves into an element which requires keyboard interaction, such as a text field

Because polyfills are only applied in enhanced experience we need to have a fallback for core experience where we use `:focus` styles instead of `:focus-visible`, we can achieve this by applying `:focus` styles only if a parent element contains the `core` class name (the `core` class name is removed from the `html` and/or `body` tag if the browser can support enhanced features). 

Spec for `:focus-visible` - https://github.com/WICG/focus-visible

The selectors need to be split up because a group of selectors containing an invalid selector is invalid as per the third bullet point in https://www.w3.org/TR/selectors-3/#Conformance