### PR TITLE
Disable browser default focus style when polyfill loaded.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -107,6 +107,10 @@
 		select.focus-visible {
 			box-shadow: 0 0 0 1px $o-normalise-focus-color;
 		}
+		// Disable browser default focus style.
+		:focus:not(.focus-visible) {
+			outline: 0;
+		}
 	}
 	// sass-lint:enable no-qualifying-elements
 


### PR DESCRIPTION
Selectively disable the default focus style by selecting for the case when the polyfill is loaded and .focus-visible is not applied to the element.

https://github.com/WICG/focus-visible#2-update-your-css