### PR TITLE
Update the focus colour to improve contrast.

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,5 +12,8 @@ $o-normalise-grid-gutters: (
 /// Standardised border radius
 $o-normalise-border-radius: 0;
 
-/// TODO: Update this to the o-colors value in the next major (it's teal-100)
-$o-normalise-focus-color: #1aecff;
+/// TODO: Update this to use o-colors/o-brand in the next major.
+$o-normalise-focus-color: #1470cc !default; // oxford-80
+@if(global-variable-exists('o-brand') == false or $o-brand == 'master') {
+	$o-normalise-focus-color: #807973 !global; // black-50
+}


### PR DESCRIPTION
This has come from the uxd team  in response to our
recent DAC accessibility audit.

- Master brand: teal-100 -> black-50 (paper/black mix) ![image](https://user-images.githubusercontent.com/1569131/58331508-363d6000-7e31-11e9-8b16-072b2656441f.png)

- Internal brand: teal-100 -> oxford-80 ![image](https://user-images.githubusercontent.com/1569131/58331548-448b7c00-7e31-11e9-9b5f-34fd08a2fb39.png)

- Whitelabel brand: teal-100 -> oxford-80 ![image](https://user-images.githubusercontent.com/1569131/58331556-46edd600-7e31-11e9-8800-0cdfc50177d1.png)
