### PR TITLE
Make the focus colour branded and optional by using o-colors.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,8 @@
 
 ### Migrating from v1 to v2
 
+`o-normalise` now depends on `o-colors`. Ensure your project builds successfully and upgrade `o-colors` if there is a conflict.
+
 #### Primary Mixin
 
 The following mixins have been removed or made private. Replace them with a single call to the `oNormalise` primary mixin, with appropriate options passed as an argument.
@@ -28,3 +30,8 @@ The following mixins have been renamed to indicate they do not output a top leve
 - `oNormaliseClearfix` becomes `oNormaliseClearfixContent`.
 - `oNormaliseVisuallyHidden` becomes `oNormaliseVisuallyHiddenContent`.
 - `oNormaliseBoxSizing` becomes `oNormaliseBoxSizingContent`.
+
+
+#### Removed Variables
+
+- `$o-normalise-focus-color` has been removed. Use the [o-colors focus usecase](https://github.com/Financial-Times/o-colors) instead.

--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,6 @@
     "main.scss"
   ],
   "dependencies": {
+    "o-colors": "^4.10.1"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,5 @@
+@import 'o-colors/main';
+
 @import 'src/scss/variables';
 @import 'src/scss/mixins';
 

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -94,13 +94,13 @@
 	body:not(.js-focus-visible) {
 		// Standardise focus styles.
 		:focus {
-			outline: 2px solid $o-normalise-focus-color;
+			outline: 2px solid $_o-normalise-focus-color;
 		}
 
 		input:focus,
 		textarea:focus,
 		select:focus {
-			box-shadow: 0 0 0 1px $o-normalise-focus-color;
+			box-shadow: 0 0 0 1px $_o-normalise-focus-color;
 		}
 	}
 
@@ -109,12 +109,12 @@
 	body.js-focus-visible {
 		// Standardise focus styles.
 		.focus-visible {
-			outline: 2px solid $o-normalise-focus-color;
+			outline: 2px solid $_o-normalise-focus-color;
 		}
 		input.focus-visible,
 		textarea.focus-visible,
 		select.focus-visible {
-			box-shadow: 0 0 0 1px $o-normalise-focus-color;
+			box-shadow: 0 0 0 1px $_o-normalise-focus-color;
 		}
 		// Disable browser default focus style.
 		:focus:not(.focus-visible) {
@@ -138,13 +138,13 @@
 	}
 
 	:focus-visible {
-		outline: 2px solid $o-normalise-focus-color;
+		outline: 2px solid $_o-normalise-focus-color;
 	}
 
 	input:focus-visible,
 	textarea:focus-visible,
 	select:focus-visible {
-		box-shadow: 0 0 0 1px $o-normalise-focus-color;
+		box-shadow: 0 0 0 1px $_o-normalise-focus-color;
 	}
 
 	// Prevent IE from putting focus styles on the body or html. These selectors

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,8 +12,5 @@ $o-normalise-grid-gutters: (
 /// Standardised border radius
 $o-normalise-border-radius: 0;
 
-/// TODO: Update this to use o-colors/o-brand in the next major.
-$o-normalise-focus-color: #1470cc !default; // oxford-80
-@if(global-variable-exists('o-brand') == false or $o-brand == 'master' or $o-brand == null) {
-	$o-normalise-focus-color: #807973 !global; // black-50
-}
+/// @access private
+$_o-normalise-focus-color: oColorsGetColorFor('focus', 'outline');


### PR DESCRIPTION
Address:
- https://github.com/Financial-Times/o-normalise/issues/40
- https://github.com/Financial-Times/o-normalise/issues/35

Relates to:
- https://github.com/Financial-Times/o-colors/pull/201