### PR TITLE
Add `clip-path` along with `clip` for `oNormaliseVisuallyHiddenContent`.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -3,6 +3,7 @@
 @mixin oNormaliseVisuallyHiddenContent {
 	position: absolute;
 	clip: rect(0 0 0 0);
+	clip-path: polygon(0 0, 0 0);
 	margin: -1px;
 	border: 0;
 	overflow: hidden;


### PR DESCRIPTION
We're doing this as `clip` is deprecated. We can't use `clip-path` over
`clip` whilst supporting IE, without using `clip-path: url()` which will
increase css bundle sizes more than just keeping `clip` as a fallback.

> Notes Internet Explorer only supports clip paths defined by url().
https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path

It's useful to add `clip-path` now to ensure future support.

Relates to: https://github.com/Financial-Times/o-normalise/issues/33