### PR TITLE
Do not set `box-sizing: border-box` by default.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,7 +8,7 @@
 
 The following mixins have been removed or made private. Replace them with a single call to the `oNormalise` primary mixin, with appropriate options passed as an argument.
 
-- `oNormaliseHTML`: set the 'body' option with 'font-smoothing', 'box-sizing', and 'focus' features.
+- `oNormaliseHTML`: set the 'body' option with 'font-smoothing', and 'focus' features.
 - `oNormaliseLinks`: add 'links' to the 'elements' option.
 - `oNormaliseText`: add 'text' to the 'elements' option.
 - `oNormaliseImages`: add 'images' to the 'elements' option.
@@ -20,7 +20,7 @@ E.g.
 - @include oNormaliseForms();
 + @include oNormalise((
 +     'elements': ('forms'),
-+     'body': ('font-smoothing', 'box-sizing', 'focus', 'reduce-motion')
++     'body': ('font-smoothing', 'focus', 'reduce-motion')
 + ));
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Foundation styles and standardised utilities
 
 ## Sass
 
-To output all `o-normalise` styles call the mixin `oNormalise`:
+To output all default `o-normalise` styles call the mixin `oNormalise`:
 
 ```scss
 @include oNormalise();
@@ -23,7 +23,7 @@ To include features of `o-normalise` granularly, pass an `$opts` map. E.g. to ou
 ```scss
 @include oNormalise($opts: (
 	'elements': ('forms', 'images', 'text', 'links'),
-	'body': ('font-smoothing', 'box-sizing', 'focus', 'reduce-motion')
+	'body': ('font-smoothing', 'focus', 'reduce-motion')
 ));
 ```
 
@@ -32,7 +32,7 @@ Options include:
 | Feature             | Description                                                                                                         | Values                                  |
 |---------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
 | elements            | Element types to apply normalising styles to.                                                                       | 'forms', 'images', 'text', 'links'      |
-| body                | Features which apply to `html`, `body`, `main` elements and all elements with a `:focus` state.                     | 'font-smoothing', 'box-sizing', 'focus' |
+| body                | Features which apply to `html`, `body`, `main` elements and all elements with a `:focus` state.                     | 'font-smoothing', 'focus' |
 | helpers             | Classes which may be applied to elements manually.                                                                  | 'clearfix', 'visually-hidden'           |
 
 _Note: if using the "focus" option in your project also include the `:focus-visible` polyfill. See [Focus States](#focus-states)._

--- a/main.scss
+++ b/main.scss
@@ -10,12 +10,12 @@
 /// @example Output all o-normalise styles, without css class helpers such as `o-normalise-visually-hidden`.
 ///     @include oNormalise($opts: (
 ///     	'elements': ('forms', 'images', 'text', 'links'),
-///     	'body': ('font-smoothing', 'box-sizing', 'focus', 'reduce-motion')
+///     	'body': ('font-smoothing', 'focus', 'reduce-motion')
 ///     ));
 /// @access public
 @mixin oNormalise($opts: (
 	'elements': ('forms', 'images', 'text', 'links'),
-	'body': ('font-smoothing', 'box-sizing', 'focus', 'reduce-motion'),
+	'body': ('font-smoothing', 'focus', 'reduce-motion'),
 	'helpers': ('clearfix', 'visually-hidden')
 )) {
 	// The elements to normalise.
@@ -28,7 +28,6 @@
 	// The body features to normalise.
 	$body: map-get($opts, 'body');
 	$font-smoothing: index($body, 'font-smoothing');
-	$box-sizing: index($body, 'box-sizing');
 	$focus: index($body, 'focus');
 	$reduce-motion: index($body, 'reduce-motion');
 
@@ -38,7 +37,7 @@
 	$visually-hidden: index($helpers, 'visually-hidden');
 
 	@if($body) {
-		@include _oNormaliseBody($font-smoothing, $box-sizing, $focus, $reduce-motion);
+		@include _oNormaliseBody($font-smoothing, false, $focus, $reduce-motion);
 	}
 
 	@if($links) {


### PR DESCRIPTION
We don't want this. We didn't have this. Don't do this.