### PR TITLE
backport: update visually-hidden width and height to 2px

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -8,8 +8,8 @@
 	border: 0;
 	overflow: hidden;
 	padding: 0;
-	width: 1px;
-	height: 1px;
+	width: 2px;
+	height: 2px;
 	white-space: nowrap;
 }
 


### PR DESCRIPTION
to better serve users with voice activation software

see: https://github.com/Financial-Times/origami/pull/346

oops: previously approved and mistakenly merged to master https://github.com/Financial-Times/o-normalise/pull/106